### PR TITLE
fix for empty line from irsend list

### DIFF
--- a/py_irsend/irsend.py
+++ b/py_irsend/irsend.py
@@ -46,7 +46,7 @@ def list_remotes(device=None, address=None):
 
     """
     output = _call(["list", "", ""], None, device, address)
-    remotes = [l.split()[-1] for l in output.splitlines()]
+    remotes = [l.split()[-1] for l in output.splitlines() if l]
     return remotes
 
 
@@ -74,7 +74,7 @@ def list_codes(remote, device=None, address=None):
 
     """
     output = _call(["list", remote, ""], None, device, address)
-    codes = [l.split()[-1] for l in output.splitlines()]
+    codes = [l.split()[-1] for l in output.splitlines() if l]
     return codes
 
 


### PR DESCRIPTION
For some reason when i run irsend list "" "" the first line of remotes is an empty line. I have looked for a faulty conf file in /etc/lirc/* but i have not found any. Without the check if a remote is a string the -1 lookup will give an index out of range error.